### PR TITLE
Add project name option

### DIFF
--- a/src/AbpHelper.Core/Commands/CommandConsts.cs
+++ b/src/AbpHelper.Core/Commands/CommandConsts.cs
@@ -5,6 +5,7 @@
         public const string OptionVariableName = "Option";
         public const string BaseDirectoryVariableName = "BaseDirectory";
         public const string ExcludeDirectoriesVariableName = "ExcludeDirectories";
+        public const string ProjectNameVariableName = "ProjectName";
         public const string OverwriteVariableName = "Overwrite";
     }
 }

--- a/src/AbpHelper.Core/Commands/CommandOptionsBase.cs
+++ b/src/AbpHelper.Core/Commands/CommandOptionsBase.cs
@@ -5,8 +5,12 @@ namespace EasyAbp.AbpHelper.Core.Commands
 {
     public abstract class CommandOptionsBase
     {
-        [Option('d', "directory", Description = "The ABP project root directory. If no directory is specified, current directory is used")]
+        [Option('d', "directory",
+            Description = "The ABP project root directory. If no directory is specified, current directory is used")]
         public virtual string Directory { get; set; } = null!;
+
+        [Option('p', "projectName", Description = "The ABP project name. If no name is provided, last part of project file name is used. Example: project file: 'Acme.BookStore.Domain.csproj', the name will be 'BookStore'")]
+        public virtual string ProjectName { get; set; } = null!;
 
         [Option("exclude", Description = "Exclude directories when searching files, arguments can contain a combination of valid literal path and wildcard (* and ?) characters. Use double asterisk(**) to search all directories. Example: --exclude *Folder1 Folder2/Folder* **/*Folder? **/*Folder*")]
         public virtual string[] Exclude { get; set; } = Array.Empty<string>();

--- a/src/AbpHelper.Core/Commands/CommandWithOption.cs
+++ b/src/AbpHelper.Core/Commands/CommandWithOption.cs
@@ -22,7 +22,8 @@ namespace EasyAbp.AbpHelper.Core.Commands
 {
     public abstract class CommandWithOption<TOption> : CommandBase where TOption : CommandOptionsBase
     {
-        public CommandWithOption(IServiceProvider serviceProvider, string name, string? description = null) : base(serviceProvider, name, description)
+        public CommandWithOption(IServiceProvider serviceProvider, string name, string? description = null) : base(
+            serviceProvider, name, description)
         {
             Logger = NullLogger<CommandWithOption<TOption>>.Instance;
 
@@ -34,6 +35,7 @@ namespace EasyAbp.AbpHelper.Core.Commands
         protected virtual string OptionVariableName => CommandConsts.OptionVariableName;
         protected virtual string BaseDirectoryVariableName => CommandConsts.BaseDirectoryVariableName;
         protected virtual string ExcludeDirectoriesVariableName => CommandConsts.ExcludeDirectoriesVariableName;
+        protected virtual string ProjectNameVariableName => CommandConsts.ProjectNameVariableName;
 
         public ILogger<CommandWithOption<TOption>> Logger { get; set; }
 
@@ -46,25 +48,33 @@ namespace EasyAbp.AbpHelper.Core.Commands
             await RunWorkflow(builder =>
             {
                 var activityBuilder = builder
-                    .StartWith<SetVariable>(
-                        step =>
-                        {
-                            step.VariableName = OptionVariableName;
-                            step.ValueExpression = new JavaScriptExpression<TOption>($"({option.ToJson()})");
-                        })
-                    .Then<SetVariable>(
-                        step =>
-                        {
-                            step.VariableName = BaseDirectoryVariableName;
-                            step.ValueExpression = new LiteralExpression(option.Directory);
-                        })
-                    .Then<SetVariable>(
-                        step =>
-                        {
-                            step.VariableName = ExcludeDirectoriesVariableName;
-                            step.ValueExpression = new JavaScriptExpression<string[]>($"{OptionVariableName}.{nameof(CommandOptionsBase.Exclude)}");
-                        })
-                    .Then<ProjectInfoProviderStep>()
+                        .StartWith<SetVariable>(
+                            step =>
+                            {
+                                step.VariableName = OptionVariableName;
+                                step.ValueExpression = new JavaScriptExpression<TOption>($"({option.ToJson()})");
+                            })
+                        .Then<SetVariable>(
+                            step =>
+                            {
+                                step.VariableName = BaseDirectoryVariableName;
+                                step.ValueExpression = new LiteralExpression(option.Directory);
+                            })
+                        .Then<SetVariable>(
+                            step =>
+                            {
+                                step.VariableName = ExcludeDirectoriesVariableName;
+                                step.ValueExpression =
+                                    new JavaScriptExpression<string[]>(
+                                        $"{OptionVariableName}.{nameof(CommandOptionsBase.Exclude)}");
+                            })
+                        .Then<SetVariable>(
+                            step =>
+                            {
+                                step.VariableName = ProjectNameVariableName;
+                                step.ValueExpression = new LiteralExpression(option.ProjectName);
+                            })
+                        .Then<ProjectInfoProviderStep>()
                     ;
 
                 return ConfigureBuild(option, activityBuilder).Build();

--- a/src/AbpHelper.Core/Models/ProjectInfo.cs
+++ b/src/AbpHelper.Core/Models/ProjectInfo.cs
@@ -1,28 +1,32 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace EasyAbp.AbpHelper.Core.Models
 {
     public class ProjectInfo
     {
-        public ProjectInfo(string baseDirectory, string fullName, TemplateType templateType, UiFramework uiFramework, bool tiered)
+        public ProjectInfo(string baseDirectory, string fullName, TemplateType templateType, UiFramework uiFramework,
+            bool tiered, string? name = null)
         {
             BaseDirectory = baseDirectory;
             TemplateType = templateType;
             UiFramework = uiFramework;
             Tiered = tiered;
             FullName = fullName;
+            Name = name ?? FullName.Split('.').Last();
         }
 
         public string BaseDirectory { get; }
         public string FullName { get; }
-        public string Name => FullName.Split('.').Last();
+        public string Name { get; }
         public TemplateType TemplateType { get; }
         public UiFramework UiFramework { get; }
         public bool Tiered { get; }
 
         public override string ToString()
         {
-            return $"{nameof(BaseDirectory)}: {BaseDirectory}, {nameof(FullName)}: {FullName}, {nameof(Name)}: {Name}, {nameof(TemplateType)}: {TemplateType}, {nameof(UiFramework)}: {UiFramework}, {nameof(Tiered)}: {Tiered}";
+            return
+                $"{nameof(BaseDirectory)}: {BaseDirectory}, {nameof(FullName)}: {FullName}, {nameof(Name)}: {Name}, {nameof(TemplateType)}: {TemplateType}, {nameof(UiFramework)}: {UiFramework}, {nameof(Tiered)}: {Tiered}";
         }
     }
 

--- a/src/AbpHelper.Core/Steps/StepWithOption.cs
+++ b/src/AbpHelper.Core/Steps/StepWithOption.cs
@@ -10,16 +10,24 @@ namespace EasyAbp.AbpHelper.Core.Steps
 {
     public abstract class StepWithOption : Step
     {
-        private static readonly Dictionary<string, IReadOnlyList<string>> ExcludeDirectorySearchCache = new Dictionary<string, IReadOnlyList<string>>();
+        private static readonly Dictionary<string, IReadOnlyList<string>> ExcludeDirectorySearchCache =
+            new Dictionary<string, IReadOnlyList<string>>();
 
         protected virtual string OptionVariableName => CommandConsts.OptionVariableName;
         protected virtual string BaseDirectoryVariableName => CommandConsts.BaseDirectoryVariableName;
+        protected virtual string ProjectNameVariableName => CommandConsts.ProjectNameVariableName;
         protected virtual string ExcludeDirectoriesVariableName => CommandConsts.ExcludeDirectoriesVariableName;
         protected virtual string OverwriteVariableName => CommandConsts.OverwriteVariableName;
 
         public WorkflowExpression<string[]> ExcludeDirectories
         {
             get => GetState(() => new JavaScriptExpression<string[]>(ExcludeDirectoriesVariableName));
+            set => SetState(value);
+        }
+
+        public WorkflowExpression<string> ProjectName
+        {
+            get => GetState(() => new JavaScriptExpression<string>(ProjectNameVariableName));
             set => SetState(value);
         }
 
@@ -35,7 +43,8 @@ namespace EasyAbp.AbpHelper.Core.Steps
             set => SetState(value);
         }
 
-        protected virtual bool FileExistsInDirectory(string directory, string pattern, params string[] excludedDirectories)
+        protected virtual bool FileExistsInDirectory(string directory, string pattern,
+            params string[] excludedDirectories)
         {
             return !SearchFileInDirectory(directory, pattern, excludedDirectories).IsNullOrWhiteSpace();
         }
@@ -69,10 +78,12 @@ namespace EasyAbp.AbpHelper.Core.Steps
                 GetExcludedDirectorySearchCacheKey(directory, excludedDirectories),
                 () => GetDirectoryFullPath(directory, excludedDirectories));
 
-            return SearchInDirectoryRecursive(directory, pattern, new HashSet<string>(excludedDirectories), Directory.EnumerateFiles);
+            return SearchInDirectoryRecursive(directory, pattern, new HashSet<string>(excludedDirectories),
+                Directory.EnumerateFiles);
         }
 
-        private IEnumerable<string> SearchInDirectoryRecursive(string directory, string pattern, HashSet<string> actualExcluded, Func<string, string, SearchOption, IEnumerable<string>> searchFunc)
+        private IEnumerable<string> SearchInDirectoryRecursive(string directory, string pattern,
+            HashSet<string> actualExcluded, Func<string, string, SearchOption, IEnumerable<string>> searchFunc)
         {
             foreach (var result in searchFunc(directory, pattern, SearchOption.TopDirectoryOnly))
             {
@@ -94,7 +105,8 @@ namespace EasyAbp.AbpHelper.Core.Steps
             }
         }
 
-        private string? FindInDirectoryRecursive(string directory, string pattern, HashSet<string> actualExcluded, Func<string, string, SearchOption, IEnumerable<string>> searchFunc)
+        private string? FindInDirectoryRecursive(string directory, string pattern, HashSet<string> actualExcluded,
+            Func<string, string, SearchOption, IEnumerable<string>> searchFunc)
         {
             var result = searchFunc(directory, pattern, SearchOption.TopDirectoryOnly).FirstOrDefault();
             if (!result.IsNullOrWhiteSpace())
@@ -139,8 +151,8 @@ namespace EasyAbp.AbpHelper.Core.Steps
                 }
 
                 foreach (var d in Directory
-                    .GetDirectories(directory, p,
-                        all ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly))
+                             .GetDirectories(directory, p,
+                                 all ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly))
                 {
                     list.Add(d);
                 }


### PR DESCRIPTION
Adding option `projectName` to customize `EasyAbp.AbpHelper.Core.Models.ProjectInfo`'s `Name` property.