### PR TITLE
Fix Multi-File Search in Directory Recursive Function

### DIFF
--- a/src/AbpHelper.Core/Steps/StepWithOption.cs
+++ b/src/AbpHelper.Core/Steps/StepWithOption.cs
@@ -96,6 +96,8 @@ namespace EasyAbp.AbpHelper.Core.Steps
             bool includeSubModules = false)
         {
             var matchedSln = false;
+            var results = new List<string>(); // Store matched files
+
             while (queue.TryDequeue(out var directory))
             {
                 if (!includeSubModules &&
@@ -109,14 +111,8 @@ namespace EasyAbp.AbpHelper.Core.Steps
                     matchedSln = true;
                 }
 
-                var result = searchFunc(directory, pattern, SearchOption.TopDirectoryOnly).FirstOrDefault();
-                if (!result.IsNullOrWhiteSpace())
-                {
-                    if (result != null)
-                    {
-                        yield return result;
-                    }
-                }
+                var files = searchFunc(directory, pattern, SearchOption.TopDirectoryOnly);
+                results.AddRange(files); // Add matched files to the collection
 
                 foreach (var d in Directory.EnumerateDirectories(directory))
                 {
@@ -128,6 +124,8 @@ namespace EasyAbp.AbpHelper.Core.Steps
                     queue.Enqueue(d);
                 }
             }
+
+            return results;
         }
 
         private static string? FindInDirectoryInQueue(Queue<string> queue, string pattern,

--- a/src/AbpHelper.Core/Steps/StepWithOption.cs
+++ b/src/AbpHelper.Core/Steps/StepWithOption.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using EasyAbp.AbpHelper.Core.Commands;
+using Elsa.Expressions;
+using Elsa.Scripting.JavaScript;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using EasyAbp.AbpHelper.Core.Commands;
-using Elsa.Expressions;
-using Elsa.Scripting.JavaScript;
 
 namespace EasyAbp.AbpHelper.Core.Steps
 {
@@ -111,9 +111,6 @@ namespace EasyAbp.AbpHelper.Core.Steps
                     matchedSln = true;
                 }
 
-                var files = searchFunc(directory, pattern, SearchOption.TopDirectoryOnly);
-                results.AddRange(files); // Add matched files to the collection
-
                 foreach (var d in Directory.EnumerateDirectories(directory))
                 {
                     if (actualExcluded.Contains(d))
@@ -123,6 +120,9 @@ namespace EasyAbp.AbpHelper.Core.Steps
 
                     queue.Enqueue(d);
                 }
+
+                var files = searchFunc(directory, pattern, SearchOption.TopDirectoryOnly);
+                results.AddRange(files); // Add matched files to the collection
             }
 
             return results;


### PR DESCRIPTION
**Enhancement:** Modify SearchInDirectoryRecursive Function to Return Multiple Files
* Update the SearchInDirectoryRecursive function to return multiple files instead of a single file in the directory search process

**Issue:** The code that provided searches for files in a specified directory and its subdirectories based on a given pattern. However, the code only returns the first matched file it encounters, rather than all files that match the pattern.

In the SearchInDirectoryRecursive method, have the following line of code:

`var result = searchFunc(directory, pattern, SearchOption.TopDirectoryOnly).FirstOrDefault();`

The FirstOrDefault() method returns the first element of the sequence, or null if no element is found. This means that only the first matched file will be returned, and the iteration will stop.

So I want to return all files that match the pattern, I have modified the code to store the results in a collection and return the collection at the end. 

This pull request is an updated of the SearchInDirectoryRecursive method that returns all matched files