### PR TITLE
Add template path configuration parameters

### DIFF
--- a/src/AbpHelper.Core/AbpHelper.Core.csproj
+++ b/src/AbpHelper.Core/AbpHelper.Core.csproj
@@ -1,45 +1,49 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\common.props" />
+	<Import Project="..\..\common.props" />
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <PackageId>EasyAbp.AbpHelper.Core</PackageId>
-    <AssemblyName>EasyAbp.AbpHelper.Core</AssemblyName>
-    <RootNamespace>EasyAbp.AbpHelper.Core</RootNamespace>
-    <LangVersion>10.0</LangVersion>
-    <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net7.0</TargetFramework>
+		<PackageId>EasyAbp.AbpHelper.Core</PackageId>
+		<AssemblyName>EasyAbp.AbpHelper.Core</AssemblyName>
+		<RootNamespace>EasyAbp.AbpHelper.Core</RootNamespace>
+		<LangVersion>10.0</LangVersion>
+		<GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Elsa" Version="1.2.2.29" />
-    <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.0" />
-    <PackageReference Include="Scriban" Version="5.5.2" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20371.2" />
-    <PackageReference Include="Volo.Abp.Autofac" Version="$(AbpVersion)" />
-    <PackageReference Include="Volo.Abp.Core" Version="$(AbpVersion)" />
-    <PackageReference Include="Volo.Abp.Http" Version="$(AbpVersion)" />
-    <PackageReference Include="Volo.Abp.VirtualFileSystem" Version="$(AbpVersion)" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-    <PackageReference Include="NuGet.Protocol" Version="6.2.2" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Elsa" Version="1.2.2.29" />
+		<PackageReference Include="Humanizer.Core" Version="2.14.1" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
+		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="7.0.0" />
+		<PackageReference Include="Scriban" Version="5.5.2" />
+		<PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20371.2" />
+		<PackageReference Include="Volo.Abp.Autofac" Version="$(AbpVersion)" />
+		<PackageReference Include="Volo.Abp.Core" Version="$(AbpVersion)" />
+		<PackageReference Include="Volo.Abp.Http" Version="$(AbpVersion)" />
+		<PackageReference Include="Volo.Abp.VirtualFileSystem" Version="$(AbpVersion)" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+		<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+		<PackageReference Include="NuGet.Protocol" Version="6.2.2" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Compile Remove="Templates\**\*.*" />
-    <Content Remove="Templates\**\*.*" />
-    <EmbeddedResource Include="Templates\**\*.*" />
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Remove="Templates\**\*.*" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Fody" Version="6.6.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="Templates\**\*.*">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Update="Fody" Version="6.6.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
 </Project>

--- a/src/AbpHelper.Core/Commands/CommandOptionsBase.cs
+++ b/src/AbpHelper.Core/Commands/CommandOptionsBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using EasyAbp.AbpHelper.Core.Attributes;
 
 namespace EasyAbp.AbpHelper.Core.Commands
@@ -14,5 +15,20 @@ namespace EasyAbp.AbpHelper.Core.Commands
 
         [Option("exclude", Description = "Exclude directories when searching files, arguments can contain a combination of valid literal path and wildcard (* and ?) characters. Use double asterisk(**) to search all directories. Example: --exclude *Folder1 Folder2/Folder* **/*Folder? **/*Folder*")]
         public virtual string[] Exclude { get; set; } = Array.Empty<string>();
+
+        [Option("templates-path", Description = "Config templates path, Built-in templates are used by default")]
+        public string? TemplatesPath { set { _templatesPath = value; } }
+
+        private string? _templatesPath = string.Empty;
+
+        public string TemplatesPathCombine(string subPath)
+        {
+            if (_templatesPath.IsNullOrWhiteSpace())
+            {
+                return Path.Combine(new[] { AppDomain.CurrentDomain.BaseDirectory, "Templates", subPath });
+            }
+
+            return Path.Combine(_templatesPath!, subPath);
+        }
     }
 }

--- a/src/AbpHelper.Core/Commands/Generate/Controller/ControllerCommand.cs
+++ b/src/AbpHelper.Core/Commands/Generate/Controller/ControllerCommand.cs
@@ -31,7 +31,7 @@ namespace EasyAbp.AbpHelper.Core.Commands.Generate.Controller
                     step =>
                     {
                         step.VariableName = VariableNames.TemplateDirectory;
-                        step.ValueExpression = new LiteralExpression<string>("/Templates/Controller");
+                        step.ValueExpression = new LiteralExpression<string>(option.GetTemplatesPath("Controller"));
                     })
                 .Then<IfElse>(
                     step => step.ConditionExpression = new JavaScriptExpression<bool>($"{OptionVariableName}.{nameof(ControllerCommandOption.SkipBuild)}"),

--- a/src/AbpHelper.Core/Commands/Generate/Controller/ControllerCommand.cs
+++ b/src/AbpHelper.Core/Commands/Generate/Controller/ControllerCommand.cs
@@ -31,7 +31,7 @@ namespace EasyAbp.AbpHelper.Core.Commands.Generate.Controller
                     step =>
                     {
                         step.VariableName = VariableNames.TemplateDirectory;
-                        step.ValueExpression = new LiteralExpression<string>(option.GetTemplatesPath("Controller"));
+                        step.ValueExpression = new LiteralExpression<string>(option.TemplatesPathCombine("Controller"));
                     })
                 .Then<IfElse>(
                     step => step.ConditionExpression = new JavaScriptExpression<bool>($"{OptionVariableName}.{nameof(ControllerCommandOption.SkipBuild)}"),

--- a/src/AbpHelper.Core/Commands/Generate/Crud/CrudCommand.cs
+++ b/src/AbpHelper.Core/Commands/Generate/Crud/CrudCommand.cs
@@ -35,7 +35,7 @@ namespace EasyAbp.AbpHelper.Core.Commands.Generate.Crud
                     step =>
                     {
                         step.VariableName = VariableNames.TemplateDirectory;
-                        step.ValueExpression = new LiteralExpression<string>("/Templates/Crud");
+                        step.ValueExpression = new LiteralExpression<string>(option.GetTemplatesPath("Crud"));
                     })
                 .Then<FileFinderStep>(
                     step => { step.SearchFileName = new LiteralExpression(entityFileName); })

--- a/src/AbpHelper.Core/Commands/Generate/Crud/CrudCommand.cs
+++ b/src/AbpHelper.Core/Commands/Generate/Crud/CrudCommand.cs
@@ -35,7 +35,7 @@ namespace EasyAbp.AbpHelper.Core.Commands.Generate.Crud
                     step =>
                     {
                         step.VariableName = VariableNames.TemplateDirectory;
-                        step.ValueExpression = new LiteralExpression<string>(option.GetTemplatesPath("Crud"));
+                        step.ValueExpression = new LiteralExpression<string>(option.TemplatesPathCombine("Crud"));
                     })
                 .Then<FileFinderStep>(
                     step => { step.SearchFileName = new LiteralExpression(entityFileName); })

--- a/src/AbpHelper.Core/Commands/Generate/GenerateCommandOption.cs
+++ b/src/AbpHelper.Core/Commands/Generate/GenerateCommandOption.cs
@@ -18,7 +18,7 @@ namespace EasyAbp.AbpHelper.Core.Commands.Generate
         {
             if (TemplatesPath.IsNullOrWhiteSpace())
             {
-                return "/Templates/" + subPath;
+                return System.AppDomain.CurrentDomain.BaseDirectory + "/Templates/" + subPath;
             }
 
             return Path.Combine(TemplatesPath!, subPath);

--- a/src/AbpHelper.Core/Commands/Generate/GenerateCommandOption.cs
+++ b/src/AbpHelper.Core/Commands/Generate/GenerateCommandOption.cs
@@ -1,6 +1,4 @@
-﻿using System.IO;
-using EasyAbp.AbpHelper.Core.Attributes;
-using NUglify.Helpers;
+﻿using EasyAbp.AbpHelper.Core.Attributes;
 
 namespace EasyAbp.AbpHelper.Core.Commands.Generate
 {
@@ -10,18 +8,5 @@ namespace EasyAbp.AbpHelper.Core.Commands.Generate
 
         [Option("no-overwrite", Description = "Specify not to overwrite existing files or content")]
         public bool NoOverwrite { get; set; }
-
-        [Option("templates-path", Description = "Config templates path, Built-in templates are used by default")]
-        public string? TemplatesPath { get; set; }
-
-        public string GetTemplatesPath(string subPath)
-        {
-            if (TemplatesPath.IsNullOrWhiteSpace())
-            {
-                return System.AppDomain.CurrentDomain.BaseDirectory + "/Templates/" + subPath;
-            }
-
-            return Path.Combine(TemplatesPath!, subPath);
-        }
     }
 }

--- a/src/AbpHelper.Core/Commands/Generate/GenerateCommandOption.cs
+++ b/src/AbpHelper.Core/Commands/Generate/GenerateCommandOption.cs
@@ -1,4 +1,6 @@
-﻿using EasyAbp.AbpHelper.Core.Attributes;
+﻿using System.IO;
+using EasyAbp.AbpHelper.Core.Attributes;
+using NUglify.Helpers;
 
 namespace EasyAbp.AbpHelper.Core.Commands.Generate
 {
@@ -8,5 +10,18 @@ namespace EasyAbp.AbpHelper.Core.Commands.Generate
 
         [Option("no-overwrite", Description = "Specify not to overwrite existing files or content")]
         public bool NoOverwrite { get; set; }
+
+        [Option("templates-path", Description = "Config templates path, Built-in templates are used by default")]
+        public string? TemplatesPath { get; set; }
+
+        public string GetTemplatesPath(string subPath)
+        {
+            if (TemplatesPath.IsNullOrWhiteSpace())
+            {
+                return "/Templates/" + subPath;
+            }
+
+            return Path.Combine(TemplatesPath!, subPath);
+        }
     }
 }

--- a/src/AbpHelper.Core/Commands/Generate/Localization/LocalizationCommand.cs
+++ b/src/AbpHelper.Core/Commands/Generate/Localization/LocalizationCommand.cs
@@ -28,7 +28,7 @@ namespace EasyAbp.AbpHelper.Core.Commands.Generate.Localization
                     step =>
                     {
                         step.VariableName = VariableNames.TemplateDirectory;
-                        step.ValueExpression = new LiteralExpression<string>("/Templates/Localization");
+                        step.ValueExpression = new LiteralExpression<string>(option.GetTemplatesPath("Localization"));
                     })
                 .Then<SetModelVariableStep>()
                 /* Add localization */

--- a/src/AbpHelper.Core/Commands/Generate/Localization/LocalizationCommand.cs
+++ b/src/AbpHelper.Core/Commands/Generate/Localization/LocalizationCommand.cs
@@ -28,7 +28,7 @@ namespace EasyAbp.AbpHelper.Core.Commands.Generate.Localization
                     step =>
                     {
                         step.VariableName = VariableNames.TemplateDirectory;
-                        step.ValueExpression = new LiteralExpression<string>(option.GetTemplatesPath("Localization"));
+                        step.ValueExpression = new LiteralExpression<string>(option.TemplatesPathCombine("Localization"));
                     })
                 .Then<SetModelVariableStep>()
                 /* Add localization */

--- a/src/AbpHelper.Core/Commands/Generate/Methods/MethodsCommand.cs
+++ b/src/AbpHelper.Core/Commands/Generate/Methods/MethodsCommand.cs
@@ -43,7 +43,7 @@ namespace EasyAbp.AbpHelper.Core.Commands.Generate.Methods
                     step =>
                     {
                         step.VariableName = VariableNames.TemplateDirectory;
-                        step.ValueExpression = new LiteralExpression<string>(option.GetTemplatesPath("Methods"));
+                        step.ValueExpression = new LiteralExpression<string>(option.TemplatesPathCombine("Methods"));
                     })
                 .Then<FileFinderStep>(
                     step =>

--- a/src/AbpHelper.Core/Commands/Generate/Methods/MethodsCommand.cs
+++ b/src/AbpHelper.Core/Commands/Generate/Methods/MethodsCommand.cs
@@ -43,7 +43,7 @@ namespace EasyAbp.AbpHelper.Core.Commands.Generate.Methods
                     step =>
                     {
                         step.VariableName = VariableNames.TemplateDirectory;
-                        step.ValueExpression = new LiteralExpression<string>("/Templates/Methods");
+                        step.ValueExpression = new LiteralExpression<string>(option.GetTemplatesPath("Methods"));
                     })
                 .Then<FileFinderStep>(
                     step =>

--- a/src/AbpHelper.Core/Commands/Generate/Service/ServiceCommand.cs
+++ b/src/AbpHelper.Core/Commands/Generate/Service/ServiceCommand.cs
@@ -38,7 +38,7 @@ namespace EasyAbp.AbpHelper.Core.Commands.Generate.Service
                     step =>
                     {
                         step.VariableName = VariableNames.TemplateDirectory;
-                        step.ValueExpression = new LiteralExpression<string>("/Templates/Service");
+                        step.ValueExpression = new LiteralExpression<string>(option.GetTemplatesPath("Service"));
                     })
                 .Then<SetModelVariableStep>()
                 .Then<GroupGenerationStep>(

--- a/src/AbpHelper.Core/Commands/Generate/Service/ServiceCommand.cs
+++ b/src/AbpHelper.Core/Commands/Generate/Service/ServiceCommand.cs
@@ -38,7 +38,7 @@ namespace EasyAbp.AbpHelper.Core.Commands.Generate.Service
                     step =>
                     {
                         step.VariableName = VariableNames.TemplateDirectory;
-                        step.ValueExpression = new LiteralExpression<string>(option.GetTemplatesPath("Service"));
+                        step.ValueExpression = new LiteralExpression<string>(option.TemplatesPathCombine("Service"));
                     })
                 .Then<SetModelVariableStep>()
                 .Then<GroupGenerationStep>(

--- a/src/AbpHelper.Core/Commands/Module/Add/AddCommand.cs
+++ b/src/AbpHelper.Core/Commands/Module/Add/AddCommand.cs
@@ -49,21 +49,21 @@ namespace EasyAbp.AbpHelper.Core.Commands.Module.Add
         protected override IActivityBuilder ConfigureBuild(AddCommandOption option, IActivityBuilder activityBuilder)
         {
             var moduleIdToCustomsMapping = typeof(ModuleCommandOption).GetProperties()
-                .Where(prop => prop.PropertyType == typeof(bool) && (bool) prop.GetValue(option)!)
+                .Where(prop => prop.PropertyType == typeof(bool) && (bool)prop.GetValue(option)!)
                 .Select(prop => _packageProjectMap[prop.Name.ToKebabCase()])
-                .ToDictionary(x => x, x => new List<string>(new[] {$"{x}:{x}"}));
-            
+                .ToDictionary(x => x, x => new List<string>(new[] { $"{x}:{x}" }));
+
             if (!option.Custom.IsNullOrEmpty())
             {
                 foreach (var customPart in option.Custom.Split(','))
                 {
                     var moduleId = customPart.Substring(0, customPart.IndexOf(':'));
-                    
+
                     if (!moduleIdToCustomsMapping.ContainsKey(moduleId))
                     {
                         moduleIdToCustomsMapping.Add(moduleId, new List<string>());
                     }
-                    
+
                     moduleIdToCustomsMapping[moduleId].Add(customPart);
                 }
             }
@@ -74,7 +74,7 @@ namespace EasyAbp.AbpHelper.Core.Commands.Module.Add
                         step =>
                         {
                             step.VariableName = VariableNames.TemplateDirectory;
-                            step.ValueExpression = new LiteralExpression<string>("/Templates/Module");
+                            step.ValueExpression = new LiteralExpression<string>(option.TemplatesPathCombine("Module"));
                         })
                     .Then<SetVariable>(
                         step =>

--- a/src/AbpHelper.Core/Commands/Module/Remove/RemoveCommand.cs
+++ b/src/AbpHelper.Core/Commands/Module/Remove/RemoveCommand.cs
@@ -49,10 +49,10 @@ namespace EasyAbp.AbpHelper.Core.Commands.Module.Remove
         protected override IActivityBuilder ConfigureBuild(RemoveCommandOption option, IActivityBuilder activityBuilder)
         {
             var moduleNameToAppProjectNameMapping = typeof(ModuleCommandOption).GetProperties()
-                .Where(prop => prop.PropertyType == typeof(bool) && (bool) prop.GetValue(option)!)
+                .Where(prop => prop.PropertyType == typeof(bool) && (bool)prop.GetValue(option)!)
                 .Select(prop => _packageProjectMap[prop.Name.ToKebabCase()])
                 .ToDictionary(x => x, x => x);
-            
+
             if (!option.Custom.IsNullOrEmpty())
             {
                 foreach (var customPart in option.Custom.Split(','))
@@ -61,7 +61,7 @@ namespace EasyAbp.AbpHelper.Core.Commands.Module.Remove
                     moduleNameToAppProjectNameMapping.Add(s[0], s[1]);
                 }
             }
-            
+
             string cdOption = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? " /d" : "";
 
             return base.ConfigureBuild(option, activityBuilder)
@@ -69,7 +69,7 @@ namespace EasyAbp.AbpHelper.Core.Commands.Module.Remove
                         step =>
                         {
                             step.VariableName = VariableNames.TemplateDirectory;
-                            step.ValueExpression = new LiteralExpression<string>("/Templates/Module");
+                            step.ValueExpression = new LiteralExpression<string>(option.TemplatesPathCombine("Module"));
                         })
                     .Then<SetVariable>(
                         step =>
@@ -137,7 +137,7 @@ namespace EasyAbp.AbpHelper.Core.Commands.Module.Remove
                                 .Then<DependsOnStep>(step =>
                                 {
                                     step.Action = new LiteralExpression<DependsOnStep.ActionType>(((int)DependsOnStep.ActionType.Remove).ToString());
-                                })                                
+                                })
                                 .Then<FileModifierStep>()
                                 .Then<IfElse>(
                                     step => step.ConditionExpression = new JavaScriptExpression<bool>("TargetAppProjectName == 'EntityFrameworkCore'"),

--- a/src/AbpHelper.Core/Generator/TextGenerator.cs
+++ b/src/AbpHelper.Core/Generator/TextGenerator.cs
@@ -26,12 +26,21 @@ namespace EasyAbp.AbpHelper.Core.Generator
         {
             return GenerateByTemplateName(templateDirectory, templateName, model, out _);
         }
-        
+
         public string GenerateByTemplateName(string templateDirectory, string templateName, object model, out TemplateContext context)
         {
             string path = Path.Combine(templateDirectory, templateName).NormalizePath();
-            var templateFile = _virtualFileProvider.GetFileInfo(path);
-            var templateText = templateFile.ReadAsString();
+
+            var templateText = "";
+            if (path.Contains(":"))
+            {
+                templateText = File.ReadAllText(path);
+            }
+            else
+            {
+                var templateFile = _virtualFileProvider.GetFileInfo(path);
+                templateText = templateFile.ReadAsString();
+            }
             return GenerateByTemplateText(templateText, model, out context);
         }
 


### PR DESCRIPTION
Specifies that the directory structure of path must be consistent with this [structure](https://github.com/EasyAbp/AbpHelper.CLI/tree/develop/src/AbpHelper.Core/Templates)

Test Steps:

1. Copy a copy of the current folder [templates](https://github.com/EasyAbp/AbpHelper.CLI/tree/develop/src/AbpHelper.Core/Templates)
2. Modify the template you need to adjust
3. Use commands `abphelper generate crud Todo -d C:\MyTodo -template-path C:\MyTemplatesCopy`